### PR TITLE
Add Entrypoint to the Engine

### DIFF
--- a/PTOS-SPM-Engine/PTOS-SPM-Engine.vcxproj
+++ b/PTOS-SPM-Engine/PTOS-SPM-Engine.vcxproj
@@ -55,7 +55,7 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>PTOS_PLATFORM_WINDOWS;PTOS_BUILD_DLL;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
@@ -69,7 +69,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>PTOS_PLATFORM_WINDOWS;PTOS_BUILD_DLL;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
     </ClCompile>
     <Link>
@@ -80,6 +80,13 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="src\Application.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="src\Application.h" />
+    <ClInclude Include="src\Core.h" />
+    <ClInclude Include="src\PTOS.h" />
+    <ClInclude Include="src\Start.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/PTOS-SPM-Engine/PTOS-SPM-Engine.vcxproj.filters
+++ b/PTOS-SPM-Engine/PTOS-SPM-Engine.vcxproj.filters
@@ -14,4 +14,23 @@
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
   </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\Application.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="src\Application.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\Core.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\Start.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\PTOS.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+  </ItemGroup>
 </Project>

--- a/PTOS-SPM-Engine/src/Application.cpp
+++ b/PTOS-SPM-Engine/src/Application.cpp
@@ -1,0 +1,11 @@
+#include "Application.h"
+
+namespace PTOS {
+	Application::Application() {
+
+	}
+
+	Application::~Application() {
+
+	}
+}

--- a/PTOS-SPM-Engine/src/Application.h
+++ b/PTOS-SPM-Engine/src/Application.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include "Core.h"
+
+namespace PTOS {
+	class PTOS_API Application
+	{
+	public:
+		Application();
+		virtual ~Application();
+
+	};
+
+	Application* createApplication(void);
+}

--- a/PTOS-SPM-Engine/src/Core.h
+++ b/PTOS-SPM-Engine/src/Core.h
@@ -1,0 +1,11 @@
+#pragma once
+
+#ifdef PTOS_PLATFORM_WINDOWS
+#ifdef PTOS_BUILD_DLL
+#define PTOS_API __declspec(dllexport)
+#else
+#define PTOS_API __declspec(dllimport)
+#endif
+#else
+#error Build not supported for this platform.
+#endif

--- a/PTOS-SPM-Engine/src/PTOS.h
+++ b/PTOS-SPM-Engine/src/PTOS.h
@@ -1,0 +1,5 @@
+#pragma once
+
+#include "Application.h"
+
+#include "Start.h"

--- a/PTOS-SPM-Engine/src/Start.h
+++ b/PTOS-SPM-Engine/src/Start.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "Application.h"
+#include "Core.h"
+
+#include <iostream>
+
+extern PTOS::Application* PTOS::createApplication(void);
+
+int main(int argc, char** argv) {
+	PTOS::Application* app = PTOS::createApplication();
+	
+	std::cout << "Start Application\n";
+
+	//TODO run application
+	while (true); //DEBUG
+
+	delete app;
+	return 0;
+}

--- a/TestEngine/TestEngine.vcxproj
+++ b/TestEngine/TestEngine.vcxproj
@@ -55,8 +55,9 @@
     <ClCompile>
       <WarningLevel>Level3</WarningLevel>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>PTOS_PLATFORM_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(SolutionDir)\PTOS-SPM-Engine\src</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -69,8 +70,9 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>
-      <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>PTOS_PLATFORM_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(SolutionDir)\PTOS-SPM-Engine\src</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -83,6 +85,9 @@
     <ProjectReference Include="..\PTOS-SPM-Engine\PTOS-SPM-Engine.vcxproj">
       <Project>{b64f659d-9878-43ff-8c3f-2601d48219f4}</Project>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\TestApp.cpp" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/TestEngine/TestEngine.vcxproj.filters
+++ b/TestEngine/TestEngine.vcxproj.filters
@@ -14,4 +14,9 @@
       <Extensions>rc;ico;cur;bmp;dlg;rc2;rct;bin;rgs;gif;jpg;jpeg;jpe;resx;tiff;tif;png;wav;mfcribbon-ms</Extensions>
     </Filter>
   </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="src\TestApp.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+  </ItemGroup>
 </Project>

--- a/TestEngine/src/TestApp.cpp
+++ b/TestEngine/src/TestApp.cpp
@@ -1,0 +1,5 @@
+#include <PTOS.h>
+
+PTOS::Application* PTOS::createApplication(void) {
+	return new Application();
+}

--- a/TestEngine/src/TestApp.cpp
+++ b/TestEngine/src/TestApp.cpp
@@ -1,5 +1,16 @@
 #include <PTOS.h>
 
+class TestApplication : public PTOS::Application {
+public:
+	TestApplication() {
+
+	}
+
+	~TestApplication() {
+
+	}
+};
+
 PTOS::Application* PTOS::createApplication(void) {
-	return new Application();
+	return new TestApplication();
 }


### PR DESCRIPTION
# Entrypoint Feature

A game can hook into the startup process of the Engine by defining bodies for certain functions.
The main function lives in Engine src/Start.h, which actually calls these functions. Currently, the only part of the startup process to hook into is creating the application (`PTOS::createApplication`).

## Notable Files

PTOS-SPM-Engine/src/
- Application.cpp
- Application.h
- Core.h
- PTOS.h
- Start.h

## Example

in Game.cpp
```
//includes Start.h
#include <PTOS.h>

//this function gets called in main
PTOS::Application* PTOS::createApplication(void) {
    //return application, with any custom modifications done
    return new Application(); 
}
```
For example using a subclass of `PTOS::Application`, see TestEngine/src/TestApp.cpp.