### PR TITLE
Add Logging

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "PTOS-SPM-Engine/libs/spdlog"]
+	path = PTOS-SPM-Engine/libs/spdlog
+	url = https://github.com/gabime/spdlog.git

--- a/PTOS-SPM-Engine/PTOS-SPM-Engine.vcxproj
+++ b/PTOS-SPM-Engine/PTOS-SPM-Engine.vcxproj
@@ -57,6 +57,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>PTOS_PLATFORM_WINDOWS;PTOS_BUILD_DLL;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(SolutionDir)\PTOS-SPM-Engine\libs\spdlog\include\</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -71,6 +72,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>PTOS_PLATFORM_WINDOWS;PTOS_BUILD_DLL;_WINDLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>$(SolutionDir)\PTOS-SPM-Engine\libs\spdlog\include\</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -81,10 +83,12 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClCompile Include="src\Application.cpp" />
+    <ClCompile Include="src\Log.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\Application.h" />
     <ClInclude Include="src\Core.h" />
+    <ClInclude Include="src\Log.h" />
     <ClInclude Include="src\PTOS.h" />
     <ClInclude Include="src\Start.h" />
   </ItemGroup>

--- a/PTOS-SPM-Engine/PTOS-SPM-Engine.vcxproj.filters
+++ b/PTOS-SPM-Engine/PTOS-SPM-Engine.vcxproj.filters
@@ -18,6 +18,9 @@
     <ClCompile Include="src\Application.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="src\Log.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="src\Application.h">
@@ -30,6 +33,9 @@
       <Filter>Header Files</Filter>
     </ClInclude>
     <ClInclude Include="src\PTOS.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="src\Log.h">
       <Filter>Header Files</Filter>
     </ClInclude>
   </ItemGroup>

--- a/PTOS-SPM-Engine/src/Log.cpp
+++ b/PTOS-SPM-Engine/src/Log.cpp
@@ -1,0 +1,27 @@
+#include "Log.h"
+
+namespace PTOS {
+	std::shared_ptr<spdlog::logger> Log::coreLogger;
+	std::shared_ptr<spdlog::logger> Log::appLogger;
+
+	void Log::init(spdlog::level::level_enum coreLevel, spdlog::level::level_enum appLevel, const std::string &appLoggerName) {
+		spdlog::set_pattern("[%T] %n: %^%v%$");
+		coreLogger = spdlog::stdout_color_mt("ENGINE");
+		coreLogger->set_level(coreLevel);
+		appLogger = spdlog::stdout_color_mt(appLoggerName);
+		appLogger->set_level(appLevel);
+		PTOS_CORE_INFO("Started Logging");
+	}
+
+	void Log::init(spdlog::level::level_enum coreLevel, spdlog::level::level_enum appLevel) {
+		init(coreLevel, appLevel, "APP");
+	}
+
+	void Log::init(const std::string& appLoggerName) {
+		init(spdlog::level::trace, spdlog::level::trace, appLoggerName);
+	}
+
+	void Log::init() {
+		init(spdlog::level::trace, spdlog::level::trace, "APP");
+	}
+}

--- a/PTOS-SPM-Engine/src/Log.h
+++ b/PTOS-SPM-Engine/src/Log.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <memory>
+
+#include "Core.h"
+#include "spdlog/spdlog.h"
+#include "spdlog/sinks/stdout_color_sinks.h"
+
+namespace PTOS {
+	class PTOS_API Log {
+	public:
+		static void init(spdlog::level::level_enum coreLevel, spdlog::level::level_enum appLevel, const std::string &appLoggerName);
+		static void init(const std::string &appLoggerName);
+		static void init(spdlog::level::level_enum coreLevel, spdlog::level::level_enum appLevel);
+		static void init();
+		static inline std::shared_ptr<spdlog::logger>& getCoreLogger(void) { return coreLogger; }
+		static inline std::shared_ptr<spdlog::logger>& getAppLogger(void) { return appLogger; }
+
+	//should not be instantiated
+	private:
+
+		static std::shared_ptr<spdlog::logger> coreLogger;
+		static std::shared_ptr<spdlog::logger> appLogger;
+
+		Log() {}
+		~Log() {}
+	};
+}
+
+//Core Logger
+#define PTOS_CORE_TRACE(...)       ::PTOS::Log::getCoreLogger()->trace(__VA_ARGS__)
+#define PTOS_CORE_DEBUG(...)       ::PTOS::Log::getCoreLogger()->debug(__VA_ARGS__)
+#define PTOS_CORE_INFO(...)        ::PTOS::Log::getCoreLogger()->info(__VA_ARGS__)
+#define PTOS_CORE_WARN(...)        ::PTOS::Log::getCoreLogger()->warn(__VA_ARGS__)
+#define PTOS_CORE_ERR(...)         ::PTOS::Log::getCoreLogger()->error(__VA_ARGS__)
+#define PTOS_CORE_CRITICAL(...)    ::PTOS::Log::getCoreLogger()->critical(__VA_ARGS__)
+
+//App Logger
+#define PTOS_TRACE(...)            ::PTOS::Log::getAppLogger()->trace(__VA_ARGS__)
+#define PTOS_DEBUG(...)            ::PTOS::Log::getAppLogger()->debug(__VA_ARGS__)
+#define PTOS_INFO(...)             ::PTOS::Log::getAppLogger()->info(__VA_ARGS__)
+#define PTOS_WARN(...)             ::PTOS::Log::getAppLogger()->warn(__VA_ARGS__)
+#define PTOS_ERR(...)              ::PTOS::Log::getAppLogger()->error(__VA_ARGS__)
+#define PTOS_CRITICAL(...)         ::PTOS::Log::getAppLogger()->critical(__VA_ARGS__)

--- a/PTOS-SPM-Engine/src/PTOS.h
+++ b/PTOS-SPM-Engine/src/PTOS.h
@@ -1,5 +1,6 @@
 #pragma once
 
 #include "Application.h"
+#include "Log.h"
 
 #include "Start.h"

--- a/PTOS-SPM-Engine/src/Start.h
+++ b/PTOS-SPM-Engine/src/Start.h
@@ -8,9 +8,10 @@
 extern PTOS::Application* PTOS::createApplication(void);
 
 int main(int argc, char** argv) {
+	PTOS::Log::init();
+	PTOS_CORE_TRACE("Creating Application");
 	PTOS::Application* app = PTOS::createApplication();
-	
-	std::cout << "Start Application\n";
+	PTOS_CORE_TRACE("Created Application");
 
 	//TODO run application
 	while (true); //DEBUG

--- a/TestEngine/TestEngine.vcxproj
+++ b/TestEngine/TestEngine.vcxproj
@@ -57,7 +57,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>PTOS_PLATFORM_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)\PTOS-SPM-Engine\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\PTOS-SPM-Engine\src;$(SolutionDir)\PTOS-SPM-Engine\libs\spdlog\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -72,7 +72,7 @@
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>PTOS_PLATFORM_WINDOWS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
-      <AdditionalIncludeDirectories>$(SolutionDir)\PTOS-SPM-Engine\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>$(SolutionDir)\PTOS-SPM-Engine\src;$(SolutionDir)\PTOS-SPM-Engine\libs\spdlog\include</AdditionalIncludeDirectories>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
# Logging Feature

A logging library, [spdlog](https://github.com/gabime/spdlog), was added as a submodule in Engine `libs/`. Utility functions and macros were made to setup and interact with this library. Two modes of logging were added: ENGINE and APP. ENGINE logging is for the Engine's use. APP logging is for the game developer's use. See `Log.h` for the defined macros.

## Notable Files

PTOS-SPM-Engine/src/
- Log.cpp
- Log.h

## Example

in Example.cpp
```cpp
//includes Log.h
#include <PTOS.h>

//hook into application creation
PTOS::Application* PTOS::createApplication(void) {
    //log message with info logging level
    PTOS_INFO("This message is logged to stdout.");

    return new Application();
}
```